### PR TITLE
Remove peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   },
   "bugs": {
     "url": "https://github.com/garysye/react-native-android-geolocation/issues"
-  },
-  "peerDependencies": {
-    "react-native": "^0.12.0"
   }
 }


### PR DESCRIPTION
Feel free to accept or reject—I'm not 100% clear on best practice—but I had to remove the peer dependency in order to prevent it from downgrading RN. Is the peer dependency necessary?
